### PR TITLE
Default subject should be host

### DIFF
--- a/lib/logstash/outputs/sns.rb
+++ b/lib/logstash/outputs/sns.rb
@@ -75,7 +75,7 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
     raise "An SNS ARN required." unless arn
 
     message = Array(event["sns_message"]).first
-    subject = Array(event["sns_subject"]).first || event.source
+    subject = Array(event["sns_subject"]).first || event["host"]
 
     # Ensure message doesn't exceed the maximum size.
     if message


### PR DESCRIPTION
As specified in the doc for sns_subject field lookup `Optional. The "%{host}" will be used if not present`

Fix for https://logstash.jira.com/browse/LOGSTASH-1954
