### PR TITLE
Ensure if host field is a String before using it as default subject

### DIFF
--- a/lib/logstash/outputs/sns.rb
+++ b/lib/logstash/outputs/sns.rb
@@ -114,7 +114,7 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
       sns_subject
     elsif sns_subject
       LogStash::Json.dump(sns_subject)
-    elsif event.get("host")
+    elsif event.get("host").is_a?(String)
       event.get("host")
     else
       NO_SUBJECT

--- a/spec/outputs/sns_spec.rb
+++ b/spec/outputs/sns_spec.rb
@@ -79,9 +79,14 @@ describe LogStash::Outputs::Sns do
       expect(subject.send(:event_subject, event)).to eql(LogStash::Json.dump(["foo", "bar"]))
     end
 
-    it "should return the host if 'sns_subject' not set" do
+    it "should return the host if 'sns_subject' not set and host is a string" do
       event = LogStash::Event.new("host" => "foo")
       expect(subject.send(:event_subject, event)).to eql("foo")
+    end
+
+    it "should return the 'NO SUBJECT' if host not a string" do
+      event = LogStash::Event.new("host" => { "name" => "foo" })
+      expect(subject.send(:event_subject, event)).to eql(LogStash::Outputs::Sns::NO_SUBJECT)
     end
 
     it "should return 'NO SUBJECT' when subject cannot be determined" do


### PR DESCRIPTION
When using Elasticbeats with `add_host_metadata` the `host` field is
a Hash not a String. Ensuring it's a `String` before using it as the
default subject value will prevent logstash from crashing.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
