### PR TITLE
Feat: handle host object as subject (due ECS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.8
+  - Feat: handle host object as subject (due ECS) [#22](https://github.com/logstash-plugins/logstash-output-sns/pull/22) 
+
 ## 4.0.7
   - Docs: Set the default_codec doc attribute.
 

--- a/lib/logstash/outputs/sns.rb
+++ b/lib/logstash/outputs/sns.rb
@@ -115,7 +115,12 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
     elsif sns_subject
       LogStash::Json.dump(sns_subject)
     elsif event.get("host")
-      event.get("host")
+      host = event.get("host")
+      if host.is_a?(Hash) # ECS mode
+        host['name'] || host['hostname'] || host['ip'] || NO_SUBJECT
+      else
+        host.to_s
+      end
     else
       NO_SUBJECT
     end

--- a/logstash-output-sns.gemspec
+++ b/logstash-output-sns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-sns'
-  s.version         = '4.0.7'
+  s.version         = '4.0.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to Amazon's Simple Notification Service"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/sns_spec.rb
+++ b/spec/outputs/sns_spec.rb
@@ -84,6 +84,24 @@ describe LogStash::Outputs::Sns do
       expect(subject.send(:event_subject, event)).to eql("foo")
     end
 
+    it "should return the host name (ECS compatibility) if 'sns_subject' not set" do
+      event = LogStash::Event.new
+      event.set('[host][hostname]', 'server1')
+      expect(subject.send(:event_subject, event)).to eql('server1')
+    end
+
+    it "should return the host IP (ECS compatibility) if 'sns_subject' not set" do
+      event = LogStash::Event.new
+      event.set('host.geo.name', 'Vychodne Pobrezie')
+      expect(subject.send(:event_subject, event)).to eql(LogStash::Outputs::Sns::NO_SUBJECT)
+    end
+
+    it "should return no subject when no info in host object (ECS compatibility) if 'sns_subject' not set" do
+      event = LogStash::Event.new
+      event.set('[host][ip]', '192.168.1.111')
+      expect(subject.send(:event_subject, event)).to eql('192.168.1.111')
+    end
+
     it "should return 'NO SUBJECT' when subject cannot be determined" do
       event = LogStash::Event.new("foo" => "bar")
       expect(subject.send(:event_subject, event)).to eql(LogStash::Outputs::Sns::NO_SUBJECT)


### PR DESCRIPTION
an ECS related update so that the output continues to use a fallback `[host]` subject for the published message